### PR TITLE
changed mimetype to content_type

### DIFF
--- a/export_xls/views.py
+++ b/export_xls/views.py
@@ -30,7 +30,7 @@ def export_xlwt(filename, fields, values_list, save=False, folder=""):
             sheet.write(row + 1, col, val, style=style)
 
     if not save:
-        response = HttpResponse(mimetype='application/vnd.ms-excel')
+        response = HttpResponse(content_type='application/vnd.ms-excel')
         response['Content-Disposition'] = 'attachment; filename=%s.xls' % filename
         book.save(response)
         return response


### PR DESCRIPTION
Just changed mimetype to content_type.
Content-Type: is one among several MIME headers. "Mimetype" does indeed sound obsolete, but a reference to MIME itself isn't. 
Now it should work in Django 1.7 and newer
